### PR TITLE
Update eQTL_mapping.R

### DIFF
--- a/R/eQTL_mapping.R
+++ b/R/eQTL_mapping.R
@@ -142,6 +142,11 @@ builtins.run_tensorqtl = run_tensorqtl
     rownames(expr) <- expr[, 1]
     expr <- expr[, -1, drop = FALSE]
     
+    expr <- t(apply(expr, 1, function(x) {
+      x[is.na(x)] <- mean(x, na.rm = TRUE)
+      x
+    }))
+    
     write.table(
       expr,
       file = expression_file_name,


### PR DESCRIPTION
When expression files contain missing values, tensorQTL returns NA for all statistics (beta, p-value, FDR). This fix imputes NAs with per-gene row means before passing the expression matrix to tensorQTL.