### PR TITLE
fix: add file LICENSE reference to License field

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Depends:
     TreeQTL,
     matrixcalc,
     reticulate
-License: GPL-3
+License: GPL-3 + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2


### PR DESCRIPTION
Changed License field to "GPL-3 + file LICENSE" so R CMD check recognizes the LICENSE file